### PR TITLE
feat(web): projected health factor for loan form and dashboard rows (…

### DIFF
--- a/apps/web/src/lib/components/create-loan/LtvIndicator.svelte
+++ b/apps/web/src/lib/components/create-loan/LtvIndicator.svelte
@@ -1,15 +1,29 @@
 <script lang="ts">
+  import type { HealthFactorResult } from '$lib/loans/loanMath';
+
   let {
     currentLtv,
     computedMaxLtv,
     ltvExceeded,
     creditScore,
+    projectedHf = null,
   }: {
     currentLtv: number;
     computedMaxLtv: number;
     ltvExceeded: boolean;
     creditScore: number | null;
+    projectedHf?: HealthFactorResult | null;
   } = $props();
+
+  const hfColor = $derived(
+    projectedHf === null
+      ? ''
+      : projectedHf.riskStatus === 'Safe'
+        ? 'text-green-500'
+        : projectedHf.riskStatus === 'Warning'
+          ? 'text-yellow-500'
+          : 'text-destructive',
+  );
 </script>
 
 <div
@@ -36,6 +50,9 @@
   <div class="flex justify-between items-center">
     <span class="text-sm font-bold {ltvExceeded ? 'text-destructive' : 'text-foreground'}">
       {currentLtv > 0 ? `${currentLtv.toFixed(1)}%` : '—'}
+      {#if projectedHf !== null}
+        <span class="font-semibold {hfColor}"> · {projectedHf.healthFactor.toFixed(2)}</span>
+      {/if}
     </span>
     {#if ltvExceeded}
       <span class="text-xs font-semibold text-destructive">Exceeds max LTV ↑</span>

--- a/apps/web/src/lib/components/create-loan/LtvIndicator.svelte
+++ b/apps/web/src/lib/components/create-loan/LtvIndicator.svelte
@@ -51,7 +51,7 @@
     <span class="text-sm font-bold {ltvExceeded ? 'text-destructive' : 'text-foreground'}">
       {currentLtv > 0 ? `${currentLtv.toFixed(1)}%` : '—'}
       {#if projectedHf !== null}
-        <span class="font-semibold {hfColor}"> · {projectedHf.healthFactor.toFixed(2)}</span>
+        <span class="font-semibold {hfColor}"> · {(Math.floor(projectedHf.healthFactor * 100) / 100).toFixed(2)}</span>
       {/if}
     </span>
     {#if ltvExceeded}

--- a/apps/web/src/lib/components/ui/CreateLoan.svelte
+++ b/apps/web/src/lib/components/ui/CreateLoan.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { axiosApi } from '$api/axiosApi';
   import { maxLtv } from '$lib/ltv';
+  import { calculateHealthFactor } from '$lib/loans/loanMath';
   import { chainInfo } from '$lib/stores/chainInfo.svelte';
   import { tokenPrices } from '$lib/stores/tokenPrices.svelte';
   import { createLoan } from '$lib/wallet/vouchVault';
@@ -47,6 +48,7 @@
   const borrowUsd = $derived((parseFloat(borrowAmount) || 0) * borrowMeta.priceUsd);
   const currentLtv = $derived(collateralUsd > 0 ? (borrowUsd / collateralUsd) * 100 : 0);
   const ltvExceeded = $derived(currentLtv > computedMaxLtv);
+  const projectedHf = $derived(calculateHealthFactor(collateralUsd, borrowUsd, computedMaxLtv));
 
   // ── Recommended APR (credit score + LTV risk) ────────────────────────────
   // Score sets the ceiling (300→15%, 850→5%). LTV utilization scales it down:
@@ -186,7 +188,7 @@
     bind:fundWindowDays
   />
 
-  <LtvIndicator {computedMaxLtv} {creditScore} {currentLtv} {ltvExceeded} />
+  <LtvIndicator {computedMaxLtv} {creditScore} {currentLtv} {ltvExceeded} {projectedHf} />
 
   {#if totalRepayment !== null}
     <RepaymentSummary

--- a/apps/web/src/lib/components/ui/HealthFactorBadge.svelte
+++ b/apps/web/src/lib/components/ui/HealthFactorBadge.svelte
@@ -20,15 +20,13 @@
           : 'Liquidation Risk',
   );
 
-  // Round healthFactor (1e18-scaled) to 2dp using bigint arithmetic throughout, so
-  // a value large enough to overflow/lose precision as a JS float still displays
-  // correctly. Rounding to 2dp of an 18dp fixed-point value is just dividing by
-  // 1e16 with round-half-up, then reinserting the decimal point — BigInt division
-  // truncates, so add half the divisor first to get round-half-up instead of
-  // round-down.
+  // Truncate (floor) healthFactor (1e18-scaled) to 2dp using bigint arithmetic.
+  // Deliberately does NOT round up: 0.9996 must display as "0.99 · Liquidation Risk",
+  // not "1.00 · Liquidation Risk" — rounding up at a threshold boundary would show
+  // a healthy-looking number next to an unhealthy status.
   const formatHealthFactor = (hf: bigint): string => {
     const scale = 10n ** 16n; // 1e18 / 100 -> 2 decimal places
-    const hundredths = (hf + scale / 2n) / scale;
+    const hundredths = hf / scale; // BigInt division truncates — no round-up bias
     const whole = hundredths / 100n;
     const frac = hundredths % 100n;
     return `${whole}.${frac.toString().padStart(2, '0')}`;

--- a/apps/web/src/lib/components/ui/LoanRepayRow.svelte
+++ b/apps/web/src/lib/components/ui/LoanRepayRow.svelte
@@ -4,11 +4,11 @@
   import LoanStatusBadge from '$lib/components/ui/LoanStatusBadge.svelte';
   import * as Table from '$lib/components/ui/table';
   import { formatUint256 } from '$lib/formatUint256';
-  import { computeProgressPct, computeRemaining, computeTotalDue, formatDueDateLabel } from '$lib/loans/loanMath';
+  import { calculateHealthFactor, computeProgressPct, computeRemaining, computeTotalDue, formatDueDateLabel } from '$lib/loans/loanMath';
   import { chainInfo } from '$lib/stores/chainInfo.svelte';
   import type { LoanFull } from '$lib/types';
   import { cn } from '$lib/utils';
-  import { cancelLoan, getHealthFactor, getRepaymentDetails, type RepaymentDetails } from '$lib/wallet/vouchVault';
+  import { cancelLoan, getHealthFactor, getLoanLiquidationThreshold, getRepaymentDetails, type RepaymentDetails } from '$lib/wallet/vouchVault';
   import { Check, Copy } from '@lucide/svelte';
   import { ethers } from 'ethers';
   import { tableColumns } from '../dashboard/columns';
@@ -84,6 +84,7 @@
   let chainError = $state('');
   let healthFactor = $state<bigint | null>(null);
   let hfLoading = $state(false);
+  let projectedHf = $state<ReturnType<typeof calculateHealthFactor>>(null);
 
   // Chain state is authoritative once loaded; DB status is the initial fallback
   // while the blockchain listener hasn't yet written the update.
@@ -132,6 +133,29 @@
       })
       .finally(() => {
         hfLoading = false;
+      });
+  });
+
+  $effect(() => {
+    if (loan.onChainLoanId === null || loan.status !== 'pending') return;
+    const collateralPriceUsd = loan.collateralToken?.price_usd ?? null;
+    const principalPriceUsd = loan.principalToken?.price_usd ?? null;
+    if (collateralPriceUsd === null || principalPriceUsd === null) return;
+
+    const collateralDecimals_ = loan.collateralToken?.decimals ?? 18;
+    const principalDecimals_ = loan.principalToken?.decimals ?? 18;
+    const collateralUsd =
+      (Number(BigInt(loan.collateralAmount ?? '0')) / 10 ** collateralDecimals_) * collateralPriceUsd;
+
+    getLoanLiquidationThreshold(BigInt(loan.onChainLoanId))
+      .then(({ liquidationThresholdBps, requestedPrincipalAmount }) => {
+        // For pending loans principalAmount in DB is 0; use the on-chain requested amount.
+        const actualBorrowedUsd =
+          (Number(requestedPrincipalAmount) / 10 ** principalDecimals_) * principalPriceUsd;
+        projectedHf = calculateHealthFactor(collateralUsd, actualBorrowedUsd, liquidationThresholdBps / 100);
+      })
+      .catch(() => {
+        projectedHf = null;
       });
   });
 
@@ -329,7 +353,20 @@
 
   <!-- Health Factor -->
   <Table.Cell class="px-2 sm:px-4 py-3 whitespace-nowrap text-center">
-    <HealthFactorBadge {healthFactor} loading={hfLoading} />
+    {#if isPending && projectedHf !== null}
+      <span
+        class="text-xs font-semibold {projectedHf.riskStatus === 'Safe'
+          ? 'text-green-500'
+          : projectedHf.riskStatus === 'Warning'
+            ? 'text-yellow-500'
+            : 'text-destructive'}"
+        title="Projected at current prices"
+      >
+        ~{projectedHf.healthFactor.toFixed(2)}
+      </span>
+    {:else}
+      <HealthFactorBadge {healthFactor} loading={hfLoading} />
+    {/if}
   </Table.Cell>
 
   <!-- Status -->

--- a/apps/web/src/lib/components/ui/LoanRepayRow.svelte
+++ b/apps/web/src/lib/components/ui/LoanRepayRow.svelte
@@ -137,26 +137,40 @@
   });
 
   $effect(() => {
-    if (loan.onChainLoanId === null || loan.status !== 'pending') return;
+    if (loan.onChainLoanId === null || loan.status !== 'pending') {
+      projectedHf = null;
+      return;
+    }
+
     const collateralPriceUsd = loan.collateralToken?.price_usd ?? null;
     const principalPriceUsd = loan.principalToken?.price_usd ?? null;
-    if (collateralPriceUsd === null || principalPriceUsd === null) return;
+    if (collateralPriceUsd === null || principalPriceUsd === null) {
+      projectedHf = null;
+      return;
+    }
 
     const collateralDecimals_ = loan.collateralToken?.decimals ?? 18;
     const principalDecimals_ = loan.principalToken?.decimals ?? 18;
     const collateralRaw = BigInt(loan.collateralAmount ?? '0');
     const collateralUsd = parseFloat(ethers.formatUnits(collateralRaw, collateralDecimals_)) * collateralPriceUsd;
 
+    let cancelled = false;
     getLoanLiquidationThreshold(BigInt(loan.onChainLoanId))
       .then(({ liquidationThresholdBps, requestedPrincipalAmount }) => {
+        if (cancelled) return;
         // For pending loans principalAmount in DB is 0; use the on-chain requested amount.
         const actualBorrowedUsd =
           parseFloat(ethers.formatUnits(requestedPrincipalAmount, principalDecimals_)) * principalPriceUsd;
         projectedHf = calculateHealthFactor(collateralUsd, actualBorrowedUsd, liquidationThresholdBps / 100);
       })
       .catch(() => {
+        if (cancelled) return;
         projectedHf = null;
       });
+
+    return () => {
+      cancelled = true;
+    };
   });
 
   // ── Due date (from DB field, fallback to chain duration) ──────────────────

--- a/apps/web/src/lib/components/ui/LoanRepayRow.svelte
+++ b/apps/web/src/lib/components/ui/LoanRepayRow.svelte
@@ -144,8 +144,8 @@
 
     const collateralDecimals_ = loan.collateralToken?.decimals ?? 18;
     const principalDecimals_ = loan.principalToken?.decimals ?? 18;
-    const collateralUsd =
-      (Number(BigInt(loan.collateralAmount ?? '0')) / 10 ** collateralDecimals_) * collateralPriceUsd;
+    const collateralRaw = BigInt(loan.collateralAmount ?? '0');
+    const collateralUsd = parseFloat(ethers.formatUnits(collateralRaw, collateralDecimals_)) * collateralPriceUsd;
 
     getLoanLiquidationThreshold(BigInt(loan.onChainLoanId))
       .then(({ liquidationThresholdBps, requestedPrincipalAmount }) => {

--- a/apps/web/src/lib/components/ui/LoanRepayRow.svelte
+++ b/apps/web/src/lib/components/ui/LoanRepayRow.svelte
@@ -362,7 +362,7 @@
             : 'text-destructive'}"
         title="Projected at current prices"
       >
-        ~{projectedHf.healthFactor.toFixed(2)}
+        ~{(Math.floor(projectedHf.healthFactor * 100) / 100).toFixed(2)}
       </span>
     {:else}
       <HealthFactorBadge {healthFactor} loading={hfLoading} />

--- a/apps/web/src/lib/components/ui/LoanRepayRow.svelte
+++ b/apps/web/src/lib/components/ui/LoanRepayRow.svelte
@@ -151,7 +151,7 @@
       .then(({ liquidationThresholdBps, requestedPrincipalAmount }) => {
         // For pending loans principalAmount in DB is 0; use the on-chain requested amount.
         const actualBorrowedUsd =
-          (Number(requestedPrincipalAmount) / 10 ** principalDecimals_) * principalPriceUsd;
+          parseFloat(ethers.formatUnits(requestedPrincipalAmount, principalDecimals_)) * principalPriceUsd;
         projectedHf = calculateHealthFactor(collateralUsd, actualBorrowedUsd, liquidationThresholdBps / 100);
       })
       .catch(() => {

--- a/apps/web/src/lib/loans/loanMath.ts
+++ b/apps/web/src/lib/loans/loanMath.ts
@@ -63,7 +63,7 @@ export const calculateHealthFactor = (
   liquidationThreshold: number,
 ): HealthFactorResult | null => {
   if (borrowedUsd <= 0 || collateralUsd <= 0) return null;
-  const healthFactor = (collateralUsd * liquidationThreshold) / (borrowedUsd * 100);
+  const healthFactor = (collateralUsd * (liquidationThreshold / 100)) / borrowedUsd;
   const riskStatus =
     healthFactor >= 1.5 ? 'Safe' : healthFactor >= 1.0 ? 'Warning' : 'Liquidation Risk';
   return { healthFactor, riskStatus };

--- a/apps/web/src/lib/loans/loanMath.ts
+++ b/apps/web/src/lib/loans/loanMath.ts
@@ -54,8 +54,8 @@ export type HealthFactorResult = {
 
 /**
  * Off-chain projection of the health factor at loan creation time.
- * Mirrors VouchVault.getHealthFactor: (collateral * threshold) / borrowed.
- * Returns null when either input is zero (no meaningful position yet).
+ * Mirrors VouchVault.getHealthFactor: (collateral * (liquidationThreshold / 100)) / borrowed.
+ * `liquidationThreshold` is expected to be a percentage in the 0–100 range (e.g. 80 for 80%).
  */
 export const calculateHealthFactor = (
   collateralUsd: number,

--- a/apps/web/src/lib/loans/loanMath.ts
+++ b/apps/web/src/lib/loans/loanMath.ts
@@ -47,6 +47,28 @@ export const computeTotalDue = (
   nowMs: number = Date.now(),
 ): bigint => principalRaw + computeAccruedInterest(principalRaw, interestRateBps, fundedAtMs, durationSeconds, nowMs);
 
+export type HealthFactorResult = {
+  healthFactor: number;
+  riskStatus: 'Safe' | 'Warning' | 'Liquidation Risk';
+};
+
+/**
+ * Off-chain projection of the health factor at loan creation time.
+ * Mirrors VouchVault.getHealthFactor: (collateral * threshold) / borrowed.
+ * Returns null when either input is zero (no meaningful position yet).
+ */
+export const calculateHealthFactor = (
+  collateralUsd: number,
+  borrowedUsd: number,
+  liquidationThreshold: number,
+): HealthFactorResult | null => {
+  if (borrowedUsd <= 0 || collateralUsd <= 0) return null;
+  const healthFactor = (collateralUsd * liquidationThreshold) / (borrowedUsd * 100);
+  const riskStatus =
+    healthFactor >= 1.5 ? 'Safe' : healthFactor >= 1.0 ? 'Warning' : 'Liquidation Risk';
+  return { healthFactor, riskStatus };
+};
+
 /** Repayment progress as a 0–100 integer percentage. */
 export const computeProgressPct = (amountRepaid: bigint, totalDue: bigint, repaid: boolean): number =>
   totalDue > 0n ? Number((amountRepaid * 100n) / totalDue) : repaid ? 100 : 0;

--- a/apps/web/src/lib/wallet/vouchVault.ts
+++ b/apps/web/src/lib/wallet/vouchVault.ts
@@ -243,6 +243,21 @@ export const getHealthFactor = async (onChainLoanId: bigint): Promise<bigint> =>
 };
 
 /**
+ * Returns on-chain fields needed to project the health factor for pending (unfunded) loans.
+ * `liquidationThresholdBps` and `requestedPrincipalAmount` are not mirrored to the database.
+ */
+export const getLoanLiquidationThreshold = async (
+  onChainLoanId: bigint,
+): Promise<{ liquidationThresholdBps: number; requestedPrincipalAmount: bigint }> => {
+  const contract = await getVouchVaultContract();
+  const loan = await contract.loans(onChainLoanId);
+  return {
+    liquidationThresholdBps: Number(loan.liquidationThresholdBps),
+    requestedPrincipalAmount: loan.requestedPrincipalAmount,
+  };
+};
+
+/**
  * Fund an active loan by sending its requested principal to the borrower.
  * Handles both native ETH (principalTokenAddress == address(0)) and ERC20 tokens.
  *


### PR DESCRIPTION
…issue #20)

- Add `calculateHealthFactor(collateralUsd, borrowedUsd, liquidationThreshold)` utility to `loanMath.ts` — pure off-chain mirror of VouchVault.getHealthFactor
- Show projected HF inline in `LtvIndicator` (loan creation form): colored number next to current LTV, e.g. "31.3% · 1.15" in warning-yellow
- Show projected HF for pending dashboard rows: reads `liquidationThresholdBps` and `requestedPrincipalAmount` from chain via `getLoanLiquidationThreshold`, displays "~1.15" with color and "Projected at current prices" tooltip
- Active loans continue to use the on-chain `getHealthFactor` RPC call

Closes #20